### PR TITLE
LDEV-991: Fix thread leaks on SQL queries

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/tag/Query.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/tag/Query.java
@@ -472,7 +472,7 @@ public final class Query extends BodyTagTryCatchFinallyImpl {
 	public int doStartTag() throws PageException	{
 
 		//timeout not defined
-		if(timeout==null || ((int)timeout.getSeconds())<=0) { // not set
+		/*if(timeout==null || ((int)timeout.getSeconds())<=0) { // not set
 			this.timeout=PageContextUtil.remainingTime(pageContext,true);
 		}
 		// timeout bigger than remaining time
@@ -480,7 +480,7 @@ public final class Query extends BodyTagTryCatchFinallyImpl {
 			TimeSpan remaining = PageContextUtil.remainingTime(pageContext,true);
 			if(timeout.getSeconds()>remaining.getSeconds())
 				timeout=remaining;
-		}
+		}*/
 		
 		
 		


### PR DESCRIPTION
This should fix thread leaking on SQL queries (at least somewhat) as documented in the issue [here.](https://luceeserver.atlassian.net/browse/LDEV-991)

The original patch is for Lucee5 but I've looked at the file in v4 and it doesn't look like much has changed so I've applied the same fixes. 