### PR TITLE
Don't kill tomcat threads

### DIFF
--- a/lucee-java/lucee-core/src/lucee/commons/io/SystemUtil.java
+++ b/lucee-java/lucee-core/src/lucee/commons/io/SystemUtil.java
@@ -1084,6 +1084,11 @@ class StopThread extends Thread {
 	}
 
 	public void run(){
+	    if (thread.getName().startsWith("mc-")) {
+            LogUtil.log(log, Log.LEVEL_ERROR, "", "Trying to stop a tomcat thread. This action is being skipped", thread.getStackTrace());
+            return;
+        }
+
 		if(pc!=null){
 			PageContextImpl pci=(PageContextImpl) pc;
 			pci.stop(t);

--- a/lucee-java/lucee-core/src/lucee/commons/io/SystemUtil.java
+++ b/lucee-java/lucee-core/src/lucee/commons/io/SystemUtil.java
@@ -1060,6 +1060,11 @@ class StopThread extends Thread {
 	}
 
 	public void run(){
+	    if (thread.getName().startsWith("mc-")) {
+            LogUtil.log(log, Log.LEVEL_ERROR, "", "Trying to stop a tomcat thread. This action is being skipped", thread.getStackTrace());
+            return;
+        }
+
 		if(pc!=null){
 			PageContextImpl pci=(PageContextImpl) pc;
 			pci.stop(t);

--- a/lucee-java/lucee-core/src/lucee/runtime/Info.ini
+++ b/lucee-java/lucee-core/src/lucee/runtime/Info.ini
@@ -1,5 +1,5 @@
 [version]
-number=4.5.3.022
+number=4.5.3.022.1
 release-date=2015/01/01 00:00:00 CET
 level=os
 state=final

--- a/lucee-java/lucee-core/src/lucee/runtime/Info.ini
+++ b/lucee-java/lucee-core/src/lucee/runtime/Info.ini
@@ -1,5 +1,5 @@
 [version]
-number=4.5.3.023
+number=4.5.3.024
 release-date=2015/01/01 00:00:00 CET
 level=os
 state=final


### PR DESCRIPTION
Anytime we kill a tomcat thread bad things happen (as in 3 hours later the site just stalls forever). Seeing as their is no logical reason to stop one of these threads we are making this change so that these threads don't get killed by Lucee anymore. 