### PR TITLE
QX-6171: add logging when EmailSender scheduled task is paused

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/Info.ini
+++ b/lucee-java/lucee-core/src/lucee/runtime/Info.ini
@@ -1,5 +1,5 @@
 [version]
-number=4.5.3.20.2
+number=4.5.3.20.3
 release-date=2015/01/01 00:00:00 CET
 level=os
 state=final

--- a/lucee-java/lucee-core/src/lucee/runtime/Info.ini
+++ b/lucee-java/lucee-core/src/lucee/runtime/Info.ini
@@ -1,5 +1,5 @@
 [version]
-number=4.5.3.20.3
+number=4.5.3.20.2
 release-date=2015/01/01 00:00:00 CET
 level=os
 state=final

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -18,12 +18,6 @@
  **/
 package lucee.runtime.schedule;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import lucee.commons.io.log.Log;
 import lucee.commons.io.log.LogAndSource;
 import lucee.commons.io.log.LogUtil;
@@ -37,7 +31,6 @@ import lucee.runtime.exp.PageException;
 import lucee.runtime.net.proxy.ProxyData;
 import lucee.runtime.net.proxy.ProxyDataImpl;
 import lucee.runtime.op.Caster;
-
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -45,6 +38,9 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * scheduler class to execute the scheduled tasks

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import lucee.commons.io.log.Log;
 import lucee.commons.io.log.LogAndSource;
+import lucee.commons.io.log.LogUtil;
 import lucee.commons.io.res.Resource;
 import lucee.commons.lang.StringUtil;
 import lucee.loader.engine.CFMLEngine;
@@ -302,7 +303,7 @@ public final class SchedulerImpl implements Scheduler {
 	@Override
 	public void pauseScheduleTask(String name, boolean pause, boolean throwWhenNotExist) throws ScheduleException, IOException {
 		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
-		boolean isEmailSenderTask = scheduledTaskUrl.endsWith("ScheduledTasks/EmailSender.cfc");
+		boolean isEmailSenderTask = scheduledTaskUrl.contains("ScheduledTasks/EmailSender.cfc");
 		//TODO: Like regex, I expected to be able to access a username String, but this breaks the application too. I would
 		//TODO: like to pass this into the logging method so logs can show who, if anyone, is pausing a task.
 //		String user = getScheduleTask(name).getCredentials().getUsername();
@@ -311,7 +312,7 @@ public final class SchedulerImpl implements Scheduler {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
 	        	tasks[i].setPaused(pause);
 				//TODO: I don't like nested conditionals, do you have a preference of a better approach?
-				if (isEmailSenderTask) {
+				if (isEmailSenderTask && pause) {
 					logPausedScheduledTask(config);
 				}
 			}
@@ -337,7 +338,12 @@ public final class SchedulerImpl implements Scheduler {
 		Log logger = getLog(config);
 
 		//TODO: At this moment, it's only logging ERROR level logs. I would like this to be INFO level.
-		logger.log(Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused");
+		try {
+			throw new RuntimeException();
+		} catch (RuntimeException ex) {
+			LogUtil.log(logger, Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused", ex);
+			// logger.log(Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused", ex);
+		}
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -304,14 +304,10 @@ public final class SchedulerImpl implements Scheduler {
 	public void pauseScheduleTask(String name, boolean pause, boolean throwWhenNotExist) throws ScheduleException, IOException {
 		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
 		boolean isEmailSenderTask = scheduledTaskUrl.contains("ScheduledTasks/EmailSender.cfc");
-		//TODO: Like regex, I expected to be able to access a username String, but this breaks the application too. I would
-		//TODO: like to pass this into the logging method so logs can show who, if anyone, is pausing a task.
-//		String user = getScheduleTask(name).getCredentials().getUsername();
 
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
 	        	tasks[i].setPaused(pause);
-				//TODO: I don't like nested conditionals, do you have a preference of a better approach?
 				if (isEmailSenderTask && pause) {
 					logPausedScheduledTask(config);
 				}
@@ -337,7 +333,6 @@ public final class SchedulerImpl implements Scheduler {
 	private void logPausedScheduledTask(Config config) throws ScheduleException {
 		Log logger = getLog(config);
 
-		//TODO: At this moment, it's only logging ERROR level logs. I would like this to be INFO level.
 		try {
 			throw new RuntimeException();
 		} catch (RuntimeException ex) {

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -337,7 +337,6 @@ public final class SchedulerImpl implements Scheduler {
 			throw new RuntimeException();
 		} catch (RuntimeException ex) {
 			LogUtil.log(logger, Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused", ex);
-			// logger.log(Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused", ex);
 		}
 	}
 

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -302,8 +302,8 @@ public final class SchedulerImpl implements Scheduler {
 
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
-				logTasksName(config, name);
 	        	tasks[i].setPaused(pause);
+				logPausedScheduledTask(config, name);
 	        }
 	    }
 	    
@@ -323,17 +323,13 @@ public final class SchedulerImpl implements Scheduler {
 		return ((ConfigImpl) config).getLog("scheduler");
 	}
 
-	private static void logEmailSender(Config config, String name) {
+	private static void logPausedScheduledTask(Config config, String name) {
 		Log logger = getLog(config);
 		Date currentTime = new Date();
 
 		//TODO: use DateTimeImpl, or more useful date format
-		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
-	}
-
-	private static void logTasksName(Config config, String name) {
-		Log logger = getLog(config);
-		logger.log(Log.LEVEL_ERROR, "", "IT CHANGED AGAIN: " + name);
+		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
+//		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -303,11 +303,10 @@ public final class SchedulerImpl implements Scheduler {
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
 	        	tasks[i].setPaused(pause);
-	        }
+				logPausedScheduledTask(config, name);
+			}
 	    }
 
-		logPausedScheduledTask(config, name);
-	    
 	    NodeList list = doc.getDocumentElement().getChildNodes();
 	    Element el=su.getElement(list,"name", name);
 	    if(el!=null) {
@@ -332,7 +331,6 @@ public final class SchedulerImpl implements Scheduler {
 
 		//TODO: use DateTimeImpl, or more useful date format
 		logger.log(Log.LEVEL_INFO, "", "This one should work");
-		logger.log(Log.LEVEL_INFO, "", currentTime);
 //		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
 //		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
 	}

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -333,7 +333,7 @@ public final class SchedulerImpl implements Scheduler {
 
 	private static void logTasksName(Config config, String name) {
 		Log logger = getLog(config);
-		logger.log(Log.LEVEL_ERROR, "", "Task name: " + name);
+		logger.log(Log.LEVEL_ERROR, "", "IT CHANGED: " + name);
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -301,11 +301,19 @@ public final class SchedulerImpl implements Scheduler {
 	
 	@Override
 	public void pauseScheduleTask(String name, boolean pause, boolean throwWhenNotExist) throws ScheduleException, IOException {
+		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
+		boolean isEmailSenderTask = scheduledTaskUrl.endsWith("ScheduledTasks/EmailSender.cfc");
+		//TODO: Like regex, I expected to be able to access a username String, but this breaks the application too. I would
+		//TODO: like to pass this into the logging method so logs can show who, if anyone, is pausing a task.
+//		String user = getScheduleTask(name).getCredentials().getUsername();
 
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
 	        	tasks[i].setPaused(pause);
-				logPausedScheduledTask(config, name);
+				//TODO: I don't like nested conditionals, do you have a preference of a better approach?
+				if (isEmailSenderTask) {
+					logPausedScheduledTask(config);
+				}
 			}
 	    }
 
@@ -325,20 +333,11 @@ public final class SchedulerImpl implements Scheduler {
 		return ((ConfigImpl) config).getLog("scheduler");
 	}
 
-	private void logPausedScheduledTask(Config config, String name) throws ScheduleException {
+	private void logPausedScheduledTask(Config config) throws ScheduleException {
 		Log logger = getLog(config);
-		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
-		boolean isEmailSenderTask = scheduledTaskUrl.endsWith("ScheduledTasks/EmailSender.cfc");
 
-		//TODO: Why does this regex break everything?
-//		String regex = ".*EmailSender\\.cfc$";
-//		Pattern pattern = Pattern.compile(regex);
-//		Matcher matcher = pattern.matcher(scheduledTaskUrl);
-//		String desiredPortion = matcher.group();
-
-		if (isEmailSenderTask) {
-			logger.log(Log.LEVEL_INFO, "", "The EmailSender scheduled task was paused");
-		}
+		//TODO: At this moment, it's only logging ERROR level logs. I would like this to be INFO level.
+		logger.log(Log.LEVEL_ERROR, "", "The EmailSender scheduled task was paused");
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -20,12 +20,15 @@ package lucee.runtime.schedule;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 
+import lucee.commons.io.log.Log;
 import lucee.commons.io.log.LogAndSource;
 import lucee.commons.io.res.Resource;
 import lucee.commons.lang.StringUtil;
 import lucee.loader.engine.CFMLEngine;
 import lucee.runtime.config.Config;
+import lucee.runtime.config.ConfigImpl;
 import lucee.runtime.engine.CFMLEngineImpl;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.net.proxy.ProxyData;
@@ -59,7 +62,6 @@ public final class SchedulerImpl implements Scheduler {
      * constructor of the sheduler
      * @param config 
      * @param schedulerDir schedule file
-     * @param log
      * @throws IOException
      * @throws SAXException
      * @throws PageException
@@ -80,7 +82,6 @@ public final class SchedulerImpl implements Scheduler {
      * creates a empty Scheduler, used for event gateway context
      * @param engine
      * @param config
-     * @param log
      * @throws SAXException
      * @throws IOException
      * @throws PageException
@@ -301,8 +302,8 @@ public final class SchedulerImpl implements Scheduler {
 
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
+				logTasksName(config, name);
 	        	tasks[i].setPaused(pause);
-	            
 	        }
 	    }
 	    
@@ -316,6 +317,23 @@ public final class SchedulerImpl implements Scheduler {
 	    
 	    //init();
 	    su.store(doc,schedulerFile);
+	}
+
+	private static Log getLog(Config config) {
+		return ((ConfigImpl) config).getLog("scheduler");
+	}
+
+	private static void logEmailSender(Config config, String name) {
+		Log logger = getLog(config);
+		Date currentTime = new Date();
+
+		//TODO: use DateTimeImpl, or more useful date format
+		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
+	}
+
+	private static void logTasksName(Config config, String name) {
+		Log logger = getLog(config);
+		logger.log(Log.LEVEL_ERROR, "", "Task name: " + name);
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -333,7 +333,7 @@ public final class SchedulerImpl implements Scheduler {
 
 	private static void logTasksName(Config config, String name) {
 		Log logger = getLog(config);
-		logger.log(Log.LEVEL_ERROR, "", "IT CHANGED: " + name);
+		logger.log(Log.LEVEL_ERROR, "", "IT CHANGED AGAIN: " + name);
 	}
 
 	@Override

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -327,18 +327,17 @@ public final class SchedulerImpl implements Scheduler {
 
 	private void logPausedScheduledTask(Config config, String name) throws ScheduleException {
 		Log logger = getLog(config);
-		String currentTime = new Date().toInstant().toString();
 		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
 		boolean isEmailSenderTask = scheduledTaskUrl.endsWith("ScheduledTasks/EmailSender.cfc");
 
+		//TODO: Why does this regex break everything?
 //		String regex = ".*EmailSender\\.cfc$";
 //		Pattern pattern = Pattern.compile(regex);
 //		Matcher matcher = pattern.matcher(scheduledTaskUrl);
 //		String desiredPortion = matcher.group();
 
-		logger.log(Log.LEVEL_ERROR, "", scheduledTaskUrl);
 		if (isEmailSenderTask) {
-			logger.log(Log.LEVEL_ERROR, "", "This is an emailsender task");
+			logger.log(Log.LEVEL_INFO, "", "The EmailSender scheduled task was paused");
 		}
 	}
 

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -323,14 +323,14 @@ public final class SchedulerImpl implements Scheduler {
 		return ((ConfigImpl) config).getLog("scheduler");
 	}
 
-	private static void logPausedScheduledTask(Config config, String name) {
+	private void logPausedScheduledTask(Config config, String name) throws ScheduleException {
 		Log logger = getLog(config);
 		String currentTime = new Date().toInstant().toString();
+		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
 
-		logger.log(Log.LEVEL_ERROR, "", "");
+		logger.log(Log.LEVEL_ERROR, "", scheduledTaskUrl);
 
 		//TODO: use DateTimeImpl, or more useful date format
-		logger.log(Log.LEVEL_INFO, "", "This one should work");
 //		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
 //		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
 	}

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -21,6 +21,8 @@ package lucee.runtime.schedule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import lucee.commons.io.log.Log;
 import lucee.commons.io.log.LogAndSource;
@@ -327,8 +329,12 @@ public final class SchedulerImpl implements Scheduler {
 		Log logger = getLog(config);
 		String currentTime = new Date().toInstant().toString();
 		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
+		String regex = ".*EmailSender\\.cfc$";
+		Pattern pattern = Pattern.compile(regex);
+		Matcher matcher = pattern.matcher(scheduledTaskUrl);
+		String desiredPortion = matcher.group();
 
-		logger.log(Log.LEVEL_ERROR, "", scheduledTaskUrl);
+		logger.log(Log.LEVEL_ERROR, "", desiredPortion);
 
 		//TODO: use DateTimeImpl, or more useful date format
 //		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -326,11 +326,13 @@ public final class SchedulerImpl implements Scheduler {
 
 	private static void logPausedScheduledTask(Config config, String name) {
 		Log logger = getLog(config);
-		Date currentTime = new Date();
+		String currentTime = new Date().toInstant().toString();
 
-		logger.log(Log.LEVEL_ERROR, "", "Test");
+		logger.log(Log.LEVEL_ERROR, "", "");
 
 		//TODO: use DateTimeImpl, or more useful date format
+		logger.log(Log.LEVEL_INFO, "", "This one should work");
+		logger.log(Log.LEVEL_INFO, "", currentTime);
 //		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
 //		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
 	}

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -303,9 +303,10 @@ public final class SchedulerImpl implements Scheduler {
 	    for(int i=0;i<tasks.length;i++) {
 	        if(tasks[i].getTask().equalsIgnoreCase(name)) {
 	        	tasks[i].setPaused(pause);
-				logPausedScheduledTask(config, name);
 	        }
 	    }
+
+		logPausedScheduledTask(config, name);
 	    
 	    NodeList list = doc.getDocumentElement().getChildNodes();
 	    Element el=su.getElement(list,"name", name);
@@ -327,8 +328,10 @@ public final class SchedulerImpl implements Scheduler {
 		Log logger = getLog(config);
 		Date currentTime = new Date();
 
+		logger.log(Log.LEVEL_ERROR, "", "Test");
+
 		//TODO: use DateTimeImpl, or more useful date format
-		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
+//		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
 //		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
 	}
 

--- a/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/schedule/SchedulerImpl.java
@@ -329,16 +329,17 @@ public final class SchedulerImpl implements Scheduler {
 		Log logger = getLog(config);
 		String currentTime = new Date().toInstant().toString();
 		String scheduledTaskUrl = getScheduleTask(name).getUrl().toString();
-		String regex = ".*EmailSender\\.cfc$";
-		Pattern pattern = Pattern.compile(regex);
-		Matcher matcher = pattern.matcher(scheduledTaskUrl);
-		String desiredPortion = matcher.group();
+		boolean isEmailSenderTask = scheduledTaskUrl.endsWith("ScheduledTasks/EmailSender.cfc");
 
-		logger.log(Log.LEVEL_ERROR, "", desiredPortion);
+//		String regex = ".*EmailSender\\.cfc$";
+//		Pattern pattern = Pattern.compile(regex);
+//		Matcher matcher = pattern.matcher(scheduledTaskUrl);
+//		String desiredPortion = matcher.group();
 
-		//TODO: use DateTimeImpl, or more useful date format
-//		logger.log(Log.LEVEL_INFO, "", "Scheduled task " + name + " paused at " + currentTime.toInstant().toString());
-//		logger.log(Log.LEVEL_INFO, "", "EmailSender scheduled task paused at " + currentTime.toInstant().toString());
+		logger.log(Log.LEVEL_ERROR, "", scheduledTaskUrl);
+		if (isEmailSenderTask) {
+			logger.log(Log.LEVEL_ERROR, "", "This is an emailsender task");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
I have a few outstanding questions for the implementation of meaningful logging. Most of these are also logged as inline TODOs .

1. I determined to the best of my ability that the only Lucee mechanism to pause a scheduled task comes through `SchedulerImpl.java` in `pauseScheduleTask()`. This is the only place where the paused field on a `ScheduleTask` object is toggled.

Is it valid to say, then, that adding a stack trace to the logging is overkill? If there's only one path through the code to lead to this outcome, I don't see the benefit of a stack trace.

2. I wanted to add a username of the person pausing the task. I noticed `ScheduleTaskImpl` has a Credentials field, from which I could access a username. I'm unsure as to if this is the username of the person who created the task or the person acting on the task, since the Java docs on the constructor only list Credentials as "proxy username and password".

If it is useful to log this username, I have not been able to figure out how to add it. Accessing the username as a string and passing it into my logging method kills the application when I put the jar on my site. This also happened when we tried to use regex to splice the scheduled task URL. I'm confused as to why adding these would kill a site if the java compiles.

3. Logs are only able to be added if they are `Log.LEVEL_ERROR`. Ideally, I'd like this to be INFO or WARN, as not all task pausings are errors. Katie and I could not figure out if this was configurable somewhere.